### PR TITLE
Updateprism

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ When prisms are created, they get stored in the node's datastore with the offer 
 
 _see `datastore`, `listdatastore`, and `deldatastore` from the [CLN docs](https://lightning.readthedocs.io/)._
 
+### updateprism
+
+**updateprism offer_id members**
+
+Replaces the array of members in a preexisting prism with the members array that gets passed.
+
 ## Testing and Experimenting
 
 The two ways I would recommend playing around with this plugin are the [roygbiv-stack](https://github.com/) and the [startup_regtest](https://github.com/ElementsProject/lightning/blob/master/contrib/startup_regtest.sh) script from the lightning repo.

--- a/prism-plugin.py
+++ b/prism-plugin.py
@@ -86,6 +86,24 @@ def listprisms(plugin):
         return e
 
 
+@plugin.method("updateprism")
+def updateprism(plugin, offer_id):
+    try:
+        # validate_members(members)
+
+        if len(plugin.rpc.listdatastore(offer_id)["datastore"]) == 0:
+            raise ValueError("prism with that ID does not exist")
+
+        prisms = get_prism_json()["prisms"]
+
+        if any(offer_id in d['offer_id'] for d in prisms):
+            plugin.log(f"{prisms}")
+
+    except RpcError as e:
+        plugin.log(e)
+        return e
+
+
 @plugin.method("deleteprism")
 def deleteprism(plugin, offer_id):
     try:

--- a/prism-plugin.py
+++ b/prism-plugin.py
@@ -87,18 +87,25 @@ def listprisms(plugin):
 
 
 @plugin.method("updateprism")
-def updateprism(plugin, offer_id):
+def updateprism(plugin, offer_id, members):
     try:
-        # validate_members(members)
+        validate_members(members)
 
         if len(plugin.rpc.listdatastore(offer_id)["datastore"]) == 0:
             raise ValueError("prism with that ID does not exist")
 
-        prisms = get_prism_json()["prisms"]
+        prisms = get_prism_json(plugin.rpc)["prisms"]
 
-        if any(offer_id in d['offer_id'] for d in prisms):
-            plugin.log(f"{prisms}")
+        if offer_id in prisms:
+            prism = prisms[offer_id]
+            prism["members"] = members
 
+            plugin.rpc.datastore(
+                key=offer_id, string=prism, mode="must-replace")
+        else:
+            raise ValueError("prism not found")
+
+        return "success"
     except RpcError as e:
         plugin.log(e)
         return e

--- a/testing/README.md
+++ b/testing/README.md
@@ -39,6 +39,12 @@ This means "paying a prism" is equivalent to paying a BOLT 12 offer.
 
 When a payment is received, the node looks up in the datastore to see if a prism exists for that offer. Then it iterates through each member paying out their deserved amount.
 
+## Updating a prism
+
+The plugin has a method called `updateprism` (see docs)
+
+I made the `update_prism.sh` script to more easily pass updates. You will need to paste in the `offer_id` of an existing prism. This script is primarily for testing the method, but could be improved to be more functional.
+
 ## Debugging
 
 There is a function in `prism-plugin.py` call `printout`.

--- a/testing/update_prism.sh
+++ b/testing/update_prism.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+
+CAROL_OFFER=$(lightning-cli --lightning-dir=/tmp/l3-regtest offer any "\"$RANDOM"\" | jq -r '.bolt12')
+DAVE_OFFER=$(lightning-cli --lightning-dir=/tmp/l4-regtest offer any "\"$RANDOM"\" | jq -r '.bolt12')
+ERIN_OFFER=$(lightning-cli --lightning-dir=/tmp/l5-regtest offer any "\"$RANDOM"\" | jq -r '.bolt12')
+
+lightning-cli --lightning-dir=/tmp/l2-regtest updateprism offer_id="0d20fe61865e988b5ea7abc40cddcc737f6b5b210e28153a2211ee50807820c8" members="[{\"name\" : \"carol\", \"destination\": \"$CAROL_OFFER\", \"split\": 5}, {\"name\": \"bob\", \"destination\": \"$DAVE_OFFER\", \"split\": 10}, {\"name\": \"erin\", \"destination\": \"$ERIN_OFFER\", \"split\": 10}]"
+


### PR DESCRIPTION
Appears to be working. The only improvement that could be made is the ability to not have to pass a whole new array of members, but I don't see how we could achieve that.

I'm thinking we can build on this method and create an `updatesplit` (issue https://github.com/daGoodenough/bolt12-prism/issues/11) method. I think splits will be what is updated most commonly.

We can also make `addprismmember` and `removeprismmember` in which the client only needs to pass a new prism object or the member's offer.